### PR TITLE
MOD-1525: Added type to button

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -39,6 +39,7 @@ export const Button: React.FC<ButtonPropsTypes> = ({
   skin = 'standard',
   theme = 'darkGreen',
   rounded = 'lg',
+  type = 'button',
   spaceBetween,
   disabled,
   fullWidth,
@@ -59,6 +60,7 @@ export const Button: React.FC<ButtonPropsTypes> = ({
     <button
       onClick={onClick}
       disabled={disabled}
+      type={type}
       className={cn({
           'pointer-events-none': disabled,
           'w-full': fullWidth,

--- a/components/Button/types.ts
+++ b/components/Button/types.ts
@@ -63,6 +63,14 @@ export type ButtonPropsTypes = {
   size?: SizeTypes;
 
   /**
+   * The `type` attribute specifies the type of button.
+   * `button`	The button is a clickable button. Component use `type: button` by default;
+   * `submit`	The button is a submit button (submits form-data);
+   * `reset`	The button is a reset button (resets the form-data to its initial values);
+   */
+  type?: 'button' | 'submit' | 'reset';
+
+  /**
    * Change the appearance of a button with a skin prop.
    * standard - is for general primary actions. This skin add primary A00 color, use as default value.
    * inline - this skin add burder. Sometime use in interface with standard button.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `type` prop for the Button component, allowing users to specify button types such as `'submit'` or `'reset'`.
  
- **Documentation**
	- Updated type definitions to include the new `type` property, enhancing clarity on button behavior in forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->